### PR TITLE
Fazer o projeto rodar localmente

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
-# projeto-final-backend-springboot
+# Projeto Final Backend Spring Boot
 
-## Database para desenvolvimento
-Caso voce nao tenha um MySql instalado na sua maquina, nos podemos rodar um banco de dados MySql localmente usando docker composer com o seguinte commando:
+## Banco de Dados para Desenvolvimento
+Se você não tiver o MySQL instalado em sua máquina, podemos executar um banco de dados MySQL localmente usando o Docker Compose com o seguinte comando:
 ```bash
-docker compose up
+docker-compose up
+```
+
+## Para Executar a Aplicação
+Para executar a aplicação pelo terminal, utilize o seguinte comando:
+```bash
+mvn spring-boot:run
+```
+
+## Testes
+Para testes rápidos, você pode interagir com a aplicação por meio do cURL. Exemplos:
+```bash
+curl -X POST -H 'Content-Type: application/json' -d '{"nome": "Rodrigo"}' http://localhost:8080/funcionario
+# Funcionário adicionado com sucesso
+```
+
+```bash
+curl http://localhost:8080/funcionario
+# [{"id":1,"nome":"Rodrigo","email":null,"senha":null,"setor":null}] 
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # projeto-final-backend-springboot
+
+## Database para desenvolvimento
+Caso voce nao tenha um MySql instalado na sua maquina, nos podemos rodar um banco de dados MySql localmente usando docker composer com o seguinte commando:
+```bash
+docker compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - 3306:3306
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_DATABASE: apispringboot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.1'
+services:
+  db:
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,4 +1,4 @@
-#Configurações do MySQL
+#Configuracoes do MySQL
 
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/apispringboot

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,4 +1,4 @@
-# Configurações para o bancoH2
+# Configuracoes para o bancoH2
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa


### PR DESCRIPTION
Eu corrigi os erros que havia na aplicação. Consulte o log de commits para obter uma melhor ideia do passo a passo.

Primeiramente, tive que corrigir os arquivos de configuração properties, pois eles não aceitavam acentos na minha máquina.

Em seguida, adicionei um Docker Compose para poder executar um MySQL localmente, com o usuário root e senha em branco, conforme especificado nas configurações.

Posteriormente, a aplicação estava iniciando, no entanto, falhava porque não conseguia encontrar o banco de dados "apispringboot". Então, adicionei esse banco de dados no MySQL.

Finalmente, a aplicação estava em execução, e realizei alguns testes básicos.